### PR TITLE
Replace the 'View on GitHub' to be dynamic based on the env vars supplied by the github build & deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,5 +38,11 @@ jobs:
     needs: build
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set REPOSITORY_URL environment variable
+        run: echo "REPOSITORY_URL=https://github.com/${{ github.repository }}" >> $GITHUB_ENV
+
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",
     "typescript": "^4.5.5",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "dotenv": "^10.0.0"
   },
   "scripts": {
     "predeploy": "npm run build",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Container from '@material-ui/core/Container';
 import Console from './component/Console';
 
 import MIDIManager from './logic/MIDIManager';
+import { REPOSITORY_URL } from './config';
 
 export default function App() {
   const [history, setHistory] = useState<string[]>([])
@@ -32,7 +33,7 @@ export default function App() {
         <h1>Web MIDI Debug</h1>
         <p>Press <code>Ctrl-K</code> or <code>Alt-K</code> to clear outputs.</p>
         <Console history={history}/>
-        <p style={{textAlign: "center"}}><a href="https://github.com/moutend/web-midi-debug">View on GitHub</a></p>
+        <p style={{textAlign: "center"}}><a href={REPOSITORY_URL}>View on GitHub</a></p>
       </Container>
     </div>
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const REPOSITORY_URL = process.env.REPOSITORY_URL;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 import App from './App';
+import './config';
 
 ReactDOM.render(
   <div>


### PR DESCRIPTION
Update the "View on GitHub" link to be dynamic based on environment variables supplied by the GitHub build & deploy action.

* **Add `src/config.ts`**: Import `dotenv` package, load environment variables from `.env` file, and export `REPOSITORY_URL` environment variable.
* **Update `package.json`**: Add `dotenv` package as a dependency.
* **Modify `src/App.tsx`**: Import `REPOSITORY_URL` from `src/config.ts` and update the "View on GitHub" link to use `REPOSITORY_URL`.
* **Update `src/index.tsx`**: Import `src/config.ts` to load environment variables.
* **Modify `.github/workflows/deploy.yml`**: Add a new step to set the `REPOSITORY_URL` environment variable using `GITHUB_REPOSITORY`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/benfoxall/web-midi-debug?shareId=be918266-0ea4-4490-bde6-6ff830b2e3e2).